### PR TITLE
Added ttw parameter to redisq call

### DIFF
--- a/src/monitorZkill.js
+++ b/src/monitorZkill.js
@@ -22,7 +22,7 @@ var monitorZkill = function (lambdaCallback) {
   };
 
   var options = {
-      url: 'https://redisq.zkillboard.com/listen.php?queueID=' + process.env.queueID,
+      url: 'https://redisq.zkillboard.com/listen.php?ttw=1&queueID=' + process.env.queueID,
       headers: headers
   };
 


### PR DESCRIPTION
I just added a ttw parameter to RedisQ which allows the calling script to only have to wait for as low as 1 second if there isn't a new killmail. This should help with Lambda and keeping the execution time shorter.

Reference:
https://github.com/zKillboard/RedisQ/commit/703a7b0fc712d04d76136d28ae67cb5e86774cee
https://github.com/zKillboard/RedisQ/commit/89884f0b217f160495518ce69ca5a727fc4dc7b3